### PR TITLE
Add Asciidoc generation

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,0 +1,26 @@
+machine:
+  node:
+    version: 0.12.0
+
+branches:
+  only:
+    - master
+
+dependencies:
+  override:
+    - "echo 'No extra dependency resolution'"
+
+general:
+  branches:
+    ignore:
+      - 'gh-pages'
+
+deployment:
+  website:
+    branch: master
+    owner: fabric8io
+    commands:
+      - git config --global user.email "circleci@fabric8.io"
+      - git config --global user.name "CircleCI"
+      - ./tools/ci-docs.sh
+

--- a/pom.xml
+++ b/pom.xml
@@ -80,6 +80,11 @@
         <maven-invoker-plugin.version>2.0.0</maven-invoker-plugin.version>
         <maven-plugin-plugin.version>3.4</maven-plugin-plugin.version>
         <maven-plugin-api.version>3.2.5</maven-plugin-api.version>
+        <maven-resources-plugin.version>3.0.0</maven-resources-plugin.version>
+        <maven-compiler-plugin.version>3.6.0</maven-compiler-plugin.version>
+        <asciidoctor-maven-plugin.version>1.5.3</asciidoctor-maven-plugin.version>
+        <asciidoctorj.version>1.5.4</asciidoctorj.version>
+        <asciidoctorj-pdf.version>1.5.0-alpha.11</asciidoctorj-pdf.version>
         <plexus-utils.version>3.0.8</plexus-utils.version>
         <junit.version>4.8.2</junit.version>
         <aether-util.version>1.0.0.v20140518</aether-util.version>
@@ -189,13 +194,14 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
+                <version>${maven-compiler-plugin.version}</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-plugin-plugin</artifactId>
                 <version>${maven-plugin-plugin.version}</version>
                 <configuration>
-                    <goalPrefix>vertx-maven-plugin</goalPrefix>
+                    <goalPrefix>vertx</goalPrefix>
                     <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                 </configuration>
                 <executions>
@@ -213,7 +219,58 @@
                     </execution>
                 </executions>
             </plugin>
+
+            <plugin>
+                <artifactId>maven-resources-plugin</artifactId>
+                <version>${maven-resources-plugin.version}</version>
+                <executions>
+                    <execution>
+                        <id>copy-asciidoc</id>
+                        <phase>process-resources</phase>
+                        <goals>
+                            <goal>copy-resources</goal>
+                        </goals>
+                        <configuration>
+                            <outputDirectory>${project.build.outputDirectory}/META-INF/doc/vmp</outputDirectory>
+                            <resources>
+                                <resource>
+                                    <directory>src/main/asciidoc</directory>
+                                    <filtering>false</filtering>
+                                </resource>
+                            </resources>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
+
+        <pluginManagement>
+            <plugins>
+                <plugin>
+                    <groupId>org.asciidoctor</groupId>
+                    <artifactId>asciidoctor-maven-plugin</artifactId>
+                    <version>${asciidoctor-maven-plugin.version}</version>
+                    <dependencies>
+                        <dependency>
+                            <groupId>org.asciidoctor</groupId>
+                            <artifactId>asciidoctorj</artifactId>
+                            <version>${asciidoctorj.version}</version>
+                        </dependency>
+                    </dependencies>
+                    <configuration>
+                        <sourceDirectory>src/main/asciidoc</sourceDirectory>
+                        <attributes>
+                            <icons>font</icons>
+                            <pagenums/>
+                            <version>${project.version}</version>
+                            <toc/>
+                            <idprefix/>
+                            <idseparator>-</idseparator>
+                        </attributes>
+                    </configuration>
+                </plugin>
+            </plugins>
+        </pluginManagement>
     </build>
 
     <profiles>
@@ -227,6 +284,7 @@
                     <plugin>
                         <groupId>org.apache.maven.plugins</groupId>
                         <artifactId>maven-invoker-plugin</artifactId>
+                        <version>${maven-invoker-plugin.version}</version>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <settingsFile>src/it/settings.xml</settingsFile>
@@ -249,6 +307,48 @@
                 </plugins>
             </build>
         </profile>
-    </profiles>
 
+        <profile>
+            <id>doc-html</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <configuration>
+                            <backend>html</backend>
+                            <sourceHighlighter>coderay</sourceHighlighter>
+                            <attributes>
+                                <toc>left</toc>
+                            </attributes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+                <defaultGoal>generate-resources asciidoctor:process-asciidoc</defaultGoal>
+            </build>
+        </profile>
+        <profile>
+            <id>doc-pdf</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.asciidoctor</groupId>
+                        <artifactId>asciidoctor-maven-plugin</artifactId>
+                        <configuration>
+                            <backend>pdf</backend>
+                            <sourceHighlighter>rouge</sourceHighlighter>
+                        </configuration>
+                        <dependencies>
+                            <dependency>
+                                <groupId>org.asciidoctor</groupId>
+                                <artifactId>asciidoctorj-pdf</artifactId>
+                                <version>${asciidoctorj-pdf.version}</version>
+                            </dependency>
+                        </dependencies>
+                    </plugin>
+                </plugins>
+                <defaultGoal>generate-resources asciidoctor:process-asciidoc</defaultGoal>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/main/asciidoc/inc/_common_configuration.adoc
+++ b/src/main/asciidoc/inc/_common_configuration.adoc
@@ -1,0 +1,19 @@
+= Common configuration
+
+All goals share the following configuration:
+
+.Package configuration
+[cols="1,5,1,1"]
+|===
+| Element | Description | Default | Property
+
+| `verticle`
+| Main verticle to start up
+|
+|`vertx.verticle`
+
+| `launcher`
+| Vert.x launcher to use
+| `io.vertx.core.Launcher`
+| `vertx.launcher`
+|===

--- a/src/main/asciidoc/inc/_goals.adoc
+++ b/src/main/asciidoc/inc/_goals.adoc
@@ -1,0 +1,16 @@
+= Maven Goals
+
+This plugin supports the following goals which are explained in detail
+in the next sections.
+
+.Plugin Goals
+[cols="1,3"]
+|===
+|Goal | Description
+
+|**<<vertx:package>>**
+|Package Vert.x applications
+
+|**<<vertx:run>>**
+|Start a Vert.x application
+|===

--- a/src/main/asciidoc/inc/_introduction.adoc
+++ b/src/main/asciidoc/inc/_introduction.adoc
@@ -1,0 +1,10 @@
+
+= Introduction
+
+This is a Maven plugin for creating http://vertx.io/[Vert.x] applications
+
+== Packaging
+
+
+== Running
+

--- a/src/main/asciidoc/inc/_vertx-package.adoc
+++ b/src/main/asciidoc/inc/_vertx-package.adoc
@@ -1,0 +1,18 @@
+
+[[vertx:package]]
+== *vertx.package*
+
+This goal will package a Vert.x application
+
+[[package-configuration]]
+=== Configuration
+
+.Package configuration
+[cols="1,5,1"]
+|===
+| Element | Description | Property
+
+|
+|
+|
+|===

--- a/src/main/asciidoc/inc/_vertx-run.adoc
+++ b/src/main/asciidoc/inc/_vertx-run.adoc
@@ -1,0 +1,13 @@
+
+[[vertx:run]]
+== *vertx:run*
+
+.Run configuration
+[cols="1,5,1"]
+|===
+| Element | Description | Property
+
+|
+|
+|
+|===

--- a/src/main/asciidoc/index.adoc
+++ b/src/main/asciidoc/index.adoc
@@ -1,0 +1,25 @@
+= kameshsampath/vertx-maven-plugin
+Kamesh Sampath;
+:revnumber: {version}
+:revdate: {localdate}
+:toc: macro
+:toclevels: 3
+:toc-title: vertx-maven-plugin
+:doctype: book
+:icons: font
+
+ifndef::ebook-format[:leveloffset: 1]
+
+(C) 2016 The original authors.
+
+ifdef::basebackend-html[toc::[]]
+
+:numbered:
+
+include::inc/_introduction.adoc[]
+
+include::inc/_common_configuration.adoc[]
+
+include::inc/_goals.adoc[]
+include::inc/_vertx-package.adoc[]
+include::inc/_vertx-run.adoc[]

--- a/src/main/java/org/workspace7/maven/plugins/PackageMojo.java
+++ b/src/main/java/org/workspace7/maven/plugins/PackageMojo.java
@@ -36,9 +36,9 @@ import java.util.Set;
  *
  */
 @Mojo(name = "package",
-        defaultPhase = LifecyclePhase.PACKAGE,
-        requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
-        requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
+    defaultPhase = LifecyclePhase.PACKAGE,
+    requiresDependencyCollection = ResolutionScope.COMPILE_PLUS_RUNTIME,
+    requiresDependencyResolution = ResolutionScope.COMPILE_PLUS_RUNTIME
 )
 public class PackageMojo extends AbstractVertxMojo {
 

--- a/tools/ci-docs.sh
+++ b/tools/ci-docs.sh
@@ -1,0 +1,15 @@
+echo ===========================================
+echo Deploying vertx-maven-plugin documentation
+echo ===========================================
+
+mvn -Pdoc-html && \
+mvn -Pdoc-pdf && \
+git clone -b gh-pages git@github.com:kameshsampath/vertx-maven-plugin gh-pages && \
+cp -rv target/generated-docs/* gh-pages/ && \
+cd gh-pages && \
+mv index.pdf docker-maven-plugin.pdf && \
+git add --ignore-errors * && \
+git commit -m "generated documentation" && \
+git push origin gh-pages && \
+cd .. && \
+rm -rf gh-pages target


### PR DESCRIPTION
* Run 'mvn -Pdoc-html' to generate the documentation in target/generated-docs
* Docs are stored in src/main/asciidoc
* tools/ci-docs.sh can be used to generate the docs and commit to branch gh-pages (needs to be created before)
* circle.yml is a circle-ci job which probably needs to be updated.

No much documentation has been added yet.